### PR TITLE
Add experimental Go port of shape with validator, tokens, normalization, and tests

### DIFF
--- a/go/PLAN.md
+++ b/go/PLAN.md
@@ -1,0 +1,119 @@
+# Go Port Plan for `shape`
+
+## Goals
+- Recreate the current TypeScript validator behavior in Go with an API that still feels like “schema-by-example”.
+- Preserve key semantics:
+  - default injection for optional fields
+  - required fields via type markers
+  - object/array recursion
+  - open vs closed object behavior
+  - composable builders (`One`, `Min`, `Max`, etc.)
+
+## Current TS behaviors to preserve
+From `src/shape.ts` and README:
+- Wrapper constructors (`String`, `Number`, `Boolean`, etc.) are interpreted as required type markers, while literal values become optional defaults.
+- Constructor names are normalized through a type-native mapping and turned into internal node types.
+- Rich builder map is exposed and attached onto the main `Shape` function.
+
+## Proposed Go directory structure
+```
+go/
+  README.md
+  go.mod
+  shape/
+    schema.go          # user-facing API (Shape, builders)
+    node.go            # internal normalized node model
+    normalize.go       # nodize-equivalent
+    validate.go        # validation engine + mutation/default-injection
+    builders.go        # composable builder funcs
+    error.go           # validation errors + formatting
+    stringify.go       # schema stringify/debug
+    tokens.go          # type-marker tokens (String/Number/Boolean...)
+    expr.go            # optional expression parser parity layer
+  examples/
+    quick/main.go
+  internal/testdata/
+  shape_test.go
+```
+
+## Go API design (schema-by-example)
+Primary API:
+```go
+compiled := shape.Shape(map[string]any{
+  "port": 8080,         // optional + default
+  "host": "localhost", // optional + default
+  "debug": shape.Boolean, // required bool
+})
+
+out, err := compiled.Validate(input)
+```
+
+### Emulating TS `String` / `Number` / `Boolean` literal trick in Go
+Go cannot use predeclared types (`string`, `int`, `bool`) as runtime values in map literals the way JS uses constructor values.
+Use **exported sentinel values**:
+
+- `shape.String`
+- `shape.Number`
+- `shape.Boolean`
+- `shape.Object`
+- `shape.Array`
+
+Implementation approach:
+- Define a private token type:
+  - `type TypeToken struct { kind Kind }`
+- Export singleton vars:
+  - `var String = TypeToken{kind: KindString}`
+  - `var Number = TypeToken{kind: KindNumber}`
+  - etc.
+- In normalization, detect `TypeToken` and mark node as required with empty/default zero values by kind.
+
+Optional ergonomic layer:
+- support `shape.Type[T]()` generic helper (`shape.Type[string]()`), useful where explicit type expression is preferred.
+- support dot-import for users who want bare `String`/`Number` tokens in source:
+  - `import . "github.com/.../shape"` (documented as optional due to namespace pollution).
+
+## Type mapping strategy for `Number`
+TS has a single `number`; Go has multiple numerics.
+- Treat `shape.Number` as accepting all integer/float kinds (`int*`, `uint*`, `float*`) by default.
+- Provide stricter builders:
+  - `shape.Int`, `shape.Float64`, etc. (optional phase-2).
+
+## Validation engine plan
+1. Normalize user schema into `Node` tree (`normalize.go`).
+2. Compile and cache immutable node graph in `Shape(...)`.
+3. Validate input recursively:
+   - inject defaults for missing optional values
+   - enforce required markers
+   - collect all errors
+4. Return updated value + aggregated error type.
+
+## Builders parity roadmap
+Phase 1 (core parity):
+- `Required`, `Optional`, `Open`, `Closed`, `One`, `Some`, `All`, `Any`, `Never`, `Min`, `Max`, `Len`, `Check`.
+
+Phase 2 (advanced parity):
+- `Before`, `After`, `Rename`, `Refer`, `Child`, `Default`, `Skip`, `Ignore`, `Rest`, key/value expression support.
+
+## Testing strategy
+- Port high-value cases from existing TS tests first:
+  - required vs default behavior
+  - object/array recursion
+  - open/closed object handling
+  - builder composition
+- Add Go table-driven tests for token handling and numeric type acceptance.
+- Add compatibility fixtures mirroring TS README examples.
+
+## Milestones
+1. **M1**: skeleton module + node model + normalize + basic validator.
+2. **M2**: token sentinels (`String/Number/Boolean`) + required/default semantics.
+3. **M3**: core builders + error aggregation + stringify.
+4. **M4**: test parity against selected TS behavior.
+5. **M5**: docs/examples and benchmark pass.
+
+## Risks and mitigations
+- **Numeric ambiguity** (`Number` in Go):
+  - Mitigation: document broad numeric acceptance and provide strict numeric builders.
+- **Mutation semantics in Go**:
+  - Mitigation: define clear in-place vs copy behavior; likely return normalized output value rather than mutating arbitrary structs unless explicitly pointer-based.
+- **DX drift from TS**:
+  - Mitigation: keep sentinel names identical (`String`, `Number`, `Boolean`) and document dot-import option for bare-token style.

--- a/go/README.md
+++ b/go/README.md
@@ -1,0 +1,40 @@
+# shape/go (experimental)
+
+This folder contains an initial Go implementation of the `shape` schema-by-example validator.
+
+## Current status
+- Supports map/object schemas using `map[string]any`.
+- Optional fields are inferred from literal defaults.
+- Required fields are declared with sentinel tokens:
+  - `shape.String`
+  - `shape.Number`
+  - `shape.Boolean`
+  - `shape.Object`
+  - `shape.Array`
+- Supports object/array recursion and default injection.
+- Objects are closed by default; use `shape.Open(...)` to allow unknown properties.
+
+## Example
+
+```go
+package main
+
+import (
+  "fmt"
+  "github.com/rjrodger/shape/go/shape"
+)
+
+func main() {
+  schema := shape.MustShape(map[string]any{
+    "port": 8080,
+    "host": "localhost",
+    "debug": shape.Boolean,
+  })
+
+  out, err := schema.Validate(map[string]any{
+    "debug": true,
+  })
+
+  fmt.Println(out, err)
+}
+```

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/rjrodger/shape/go
+
+go 1.22

--- a/go/shape/compat_tsv_test.go
+++ b/go/shape/compat_tsv_test.go
@@ -1,0 +1,178 @@
+package shape
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+type compatRow struct {
+	Name   string
+	Spec   any
+	Input  any
+	Output any
+	Err    string
+}
+
+func TestCompatTSV(t *testing.T) {
+	rows := loadCompatRows(t)
+
+	for _, row := range rows {
+		t.Run(row.Name, func(t *testing.T) {
+			s := MustShape(decodeSpec(row.Spec))
+			out, err := s.Validate(row.Input)
+
+			if row.Err != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q", row.Err)
+				}
+				if !strings.Contains(strings.ToLower(err.Error()), strings.ToLower(row.Err)) {
+					t.Fatalf("expected error containing %q, got %q", row.Err, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+
+			if !reflect.DeepEqual(out, row.Output) {
+				t.Fatalf("output mismatch\nexpected: %#v\nactual:   %#v", row.Output, out)
+			}
+		})
+	}
+}
+
+func loadCompatRows(t *testing.T) []compatRow {
+	t.Helper()
+
+	path := filepath.Join("..", "..", "test", "compat.tsv")
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open %s: %v", path, err)
+	}
+	defer f.Close()
+
+	sc := bufio.NewScanner(f)
+	if !sc.Scan() {
+		t.Fatal("compat.tsv is empty")
+	}
+
+	headers := strings.Split(sc.Text(), "\t")
+	idx := map[string]int{}
+	for i, h := range headers {
+		idx[h] = i
+	}
+
+	var out []compatRow
+	for sc.Scan() {
+		line := sc.Text()
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		cols := strings.Split(line, "\t")
+
+		row := compatRow{
+			Name:   col(cols, idx, "name"),
+			Spec:   parseValueCell(t, col(cols, idx, "spec")),
+			Input:  parseValueCell(t, col(cols, idx, "input")),
+			Output: parseValueCell(t, col(cols, idx, "output")),
+			Err:    col(cols, idx, "error"),
+		}
+		out = append(out, row)
+	}
+
+	if err := sc.Err(); err != nil {
+		t.Fatalf("scan compat.tsv: %v", err)
+	}
+
+	return out
+}
+
+func col(cols []string, idx map[string]int, key string) string {
+	i, ok := idx[key]
+	if !ok || i >= len(cols) {
+		return ""
+	}
+	return cols[i]
+}
+
+func parseValueCell(t *testing.T, src string) any {
+	t.Helper()
+	src = strings.TrimSpace(src)
+
+	var v any
+	if err := json.Unmarshal([]byte(src), &v); err == nil {
+		return v
+	}
+
+	if len(src) >= 2 {
+		q0 := src[0]
+		q1 := src[len(src)-1]
+		if (q0 == '\'' && q1 == '\'') || (q0 == '"' && q1 == '"') {
+			return src[1 : len(src)-1]
+		}
+	}
+
+	return src
+}
+
+func decodeSpec(v any) any {
+	if arr, ok := v.([]any); ok {
+		out := make([]any, len(arr))
+		for i := range arr {
+			out[i] = decodeSpec(arr[i])
+		}
+		return out
+	}
+
+	obj, ok := v.(map[string]any)
+	if !ok {
+		return v
+	}
+
+	if len(obj) == 1 {
+		if tv, ok := obj["$type"]; ok {
+			if ts, ok := tv.(string); ok {
+				switch ts {
+				case "Any":
+					return Any
+				case "String":
+					return String
+				case "Number":
+					return Number
+				case "Boolean":
+					return Boolean
+				case "Object":
+					return Object
+				case "Array":
+					return Array
+				}
+			}
+		}
+
+		if ov, ok := obj["$open"]; ok {
+			return Open(decodeSpec(ov))
+		}
+		if cv, ok := obj["$closed"]; ok {
+			return Closed(decodeSpec(cv))
+		}
+		if rv, ok := obj["$required"]; ok {
+			return Required(decodeSpec(rv))
+		}
+		if ov, ok := obj["$optional"]; ok {
+			return Optional(decodeSpec(ov))
+		}
+	}
+
+	out := map[string]any{}
+	for k, subv := range obj {
+		out[k] = decodeSpec(subv)
+	}
+
+	return out
+}

--- a/go/shape/error.go
+++ b/go/shape/error.go
@@ -1,0 +1,41 @@
+package shape
+
+import (
+	"fmt"
+	"strings"
+)
+
+type FieldError struct {
+	Path string
+	Why  string
+}
+
+func (e FieldError) Error() string {
+	if e.Path == "" {
+		return e.Why
+	}
+	return fmt.Sprintf("%s: %s", e.Path, e.Why)
+}
+
+type ValidationError struct {
+	Issues []FieldError
+}
+
+func (e *ValidationError) Error() string {
+	if e == nil || len(e.Issues) == 0 {
+		return ""
+	}
+	parts := make([]string, len(e.Issues))
+	for i, issue := range e.Issues {
+		parts[i] = issue.Error()
+	}
+	return strings.Join(parts, "; ")
+}
+
+func (e *ValidationError) add(path, why string) {
+	e.Issues = append(e.Issues, FieldError{Path: path, Why: why})
+}
+
+func (e *ValidationError) hasAny() bool {
+	return e != nil && len(e.Issues) > 0
+}

--- a/go/shape/node.go
+++ b/go/shape/node.go
@@ -1,0 +1,43 @@
+package shape
+
+type node struct {
+	kind Kind
+
+	required bool
+	open     bool
+
+	defaultValue any
+
+	objChildren map[string]*node
+	arrChild    *node
+}
+
+type wrappedSpec struct {
+	spec     any
+	required *bool
+	open     *bool
+}
+
+// Required marks a schema fragment as required.
+func Required(spec any) any {
+	v := true
+	return wrappedSpec{spec: spec, required: &v}
+}
+
+// Optional marks a schema fragment as optional.
+func Optional(spec any) any {
+	v := false
+	return wrappedSpec{spec: spec, required: &v}
+}
+
+// Open allows additional properties on object schemas.
+func Open(spec any) any {
+	v := true
+	return wrappedSpec{spec: spec, open: &v}
+}
+
+// Closed forbids additional properties on object schemas.
+func Closed(spec any) any {
+	v := false
+	return wrappedSpec{spec: spec, open: &v}
+}

--- a/go/shape/normalize.go
+++ b/go/shape/normalize.go
@@ -1,0 +1,80 @@
+package shape
+
+import "fmt"
+
+func normalize(spec any) (*node, error) {
+	reqOverride, openOverride, base := unwrap(spec)
+
+	n, err := normalizeBase(base)
+	if err != nil {
+		return nil, err
+	}
+
+	if reqOverride != nil {
+		n.required = *reqOverride
+	}
+	if openOverride != nil && n.kind == KindObject {
+		n.open = *openOverride
+	}
+
+	return n, nil
+}
+
+func unwrap(spec any) (required *bool, open *bool, base any) {
+	base = spec
+	for {
+		w, ok := base.(wrappedSpec)
+		if !ok {
+			return required, open, base
+		}
+		if w.required != nil {
+			required = w.required
+		}
+		if w.open != nil {
+			open = w.open
+		}
+		base = w.spec
+	}
+}
+
+func normalizeBase(spec any) (*node, error) {
+	switch v := spec.(type) {
+	case nil:
+		return &node{kind: KindNull, defaultValue: nil}, nil
+	case TypeToken:
+		return &node{kind: v.kind, required: true}, nil
+	case string:
+		return &node{kind: KindString, defaultValue: v}, nil
+	case bool:
+		return &node{kind: KindBoolean, defaultValue: v}, nil
+	case int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64,
+		float32, float64:
+		return &node{kind: KindNumber, defaultValue: v}, nil
+	case []any:
+		n := &node{kind: KindArray, defaultValue: []any{}}
+		if len(v) == 1 {
+			child, err := normalize(v[0])
+			if err != nil {
+				return nil, err
+			}
+			n.arrChild = child
+		}
+		return n, nil
+	case map[string]any:
+		n := &node{kind: KindObject, objChildren: map[string]*node{}, defaultValue: map[string]any{}, open: false}
+		for k, sv := range v {
+			cn, err := normalize(sv)
+			if err != nil {
+				return nil, fmt.Errorf("key %q: %w", k, err)
+			}
+			n.objChildren[k] = cn
+		}
+		if len(v) == 0 {
+			n.open = true
+		}
+		return n, nil
+	default:
+		return nil, fmt.Errorf("unsupported schema value type %T", spec)
+	}
+}

--- a/go/shape/schema.go
+++ b/go/shape/schema.go
@@ -1,0 +1,38 @@
+package shape
+
+// Schema is a compiled shape specification.
+type Schema struct {
+	root *node
+}
+
+// Shape compiles a schema-by-example specification.
+func Shape(spec any) (*Schema, error) {
+	n, err := normalize(spec)
+	if err != nil {
+		return nil, err
+	}
+	return &Schema{root: n}, nil
+}
+
+// MustShape compiles a schema and panics if invalid.
+func MustShape(spec any) *Schema {
+	s, err := Shape(spec)
+	if err != nil {
+		panic(err)
+	}
+	return s
+}
+
+// Validate validates and normalizes input according to the compiled schema.
+// It returns a new value with defaults injected.
+func (s *Schema) Validate(input any) (any, error) {
+	if s == nil || s.root == nil {
+		return nil, nil
+	}
+	verr := &ValidationError{}
+	out := validateNode(s.root, input, "$", verr)
+	if verr.hasAny() {
+		return out, verr
+	}
+	return out, nil
+}

--- a/go/shape/shape_test.go
+++ b/go/shape/shape_test.go
@@ -1,0 +1,49 @@
+package shape
+
+import "testing"
+
+func TestDefaultsAndRequiredToken(t *testing.T) {
+	s := MustShape(map[string]any{
+		"port":  8080,
+		"host":  "localhost",
+		"debug": Boolean,
+	})
+
+	out, err := s.Validate(map[string]any{"debug": true})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	obj := out.(map[string]any)
+	if obj["port"] != 8080 || obj["host"] != "localhost" || obj["debug"] != true {
+		t.Fatalf("unexpected output: %#v", obj)
+	}
+}
+
+func TestClosedObjectRejectsUnknown(t *testing.T) {
+	s := MustShape(map[string]any{"a": 1})
+	_, err := s.Validate(map[string]any{"a": 2, "b": true})
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+}
+
+func TestOpenObjectAllowsUnknown(t *testing.T) {
+	s := MustShape(Open(map[string]any{"a": 1}))
+	out, err := s.Validate(map[string]any{"a": 2, "b": true})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	obj := out.(map[string]any)
+	if obj["b"] != true {
+		t.Fatalf("expected b to be preserved: %#v", obj)
+	}
+}
+
+func TestArrayChildValidation(t *testing.T) {
+	s := MustShape([]any{Number})
+	_, err := s.Validate([]any{1, 2, "x"})
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+}

--- a/go/shape/tokens.go
+++ b/go/shape/tokens.go
@@ -1,0 +1,31 @@
+package shape
+
+// Kind identifies a normalized schema/value kind.
+type Kind string
+
+const (
+	KindAny     Kind = "any"
+	KindString  Kind = "string"
+	KindNumber  Kind = "number"
+	KindBoolean Kind = "boolean"
+	KindObject  Kind = "object"
+	KindArray   Kind = "array"
+	KindNull    Kind = "null"
+)
+
+// TypeToken marks a required type in schema-by-example maps.
+type TypeToken struct {
+	kind Kind
+}
+
+func (t TypeToken) Kind() Kind { return t.kind }
+
+// Sentinel tokens for required fields (TS constructor-literal equivalent).
+var (
+	Any     = TypeToken{kind: KindAny}
+	String  = TypeToken{kind: KindString}
+	Number  = TypeToken{kind: KindNumber}
+	Boolean = TypeToken{kind: KindBoolean}
+	Object  = TypeToken{kind: KindObject}
+	Array   = TypeToken{kind: KindArray}
+)

--- a/go/shape/validate.go
+++ b/go/shape/validate.go
@@ -1,0 +1,132 @@
+package shape
+
+import (
+	"fmt"
+)
+
+func validateNode(n *node, in any, path string, verr *ValidationError) any {
+	if n == nil {
+		return in
+	}
+
+	if in == nil {
+		if n.required {
+			verr.add(path, "value is required")
+			return nil
+		}
+		return cloneDefault(n)
+	}
+
+	switch n.kind {
+	case KindAny:
+		return in
+	case KindString:
+		if _, ok := in.(string); !ok {
+			verr.add(path, "expected string")
+			return in
+		}
+		return in
+	case KindBoolean:
+		if _, ok := in.(bool); !ok {
+			verr.add(path, "expected boolean")
+			return in
+		}
+		return in
+	case KindNumber:
+		if !isNumber(in) {
+			verr.add(path, "expected number")
+			return in
+		}
+		return in
+	case KindNull:
+		if in != nil {
+			verr.add(path, "expected null")
+		}
+		return nil
+	case KindArray:
+		arr, ok := in.([]any)
+		if !ok {
+			verr.add(path, "expected array ([]any)")
+			return in
+		}
+		if n.arrChild == nil {
+			return arr
+		}
+		out := make([]any, len(arr))
+		for i := range arr {
+			out[i] = validateNode(n.arrChild, arr[i], fmt.Sprintf("%s[%d]", path, i), verr)
+		}
+		return out
+	case KindObject:
+		obj, ok := in.(map[string]any)
+		if !ok {
+			verr.add(path, "expected object (map[string]any)")
+			return in
+		}
+
+		out := map[string]any{}
+		for k, v := range obj {
+			out[k] = v
+		}
+
+		for k, cn := range n.objChildren {
+			v, has := obj[k]
+			kpath := path + "." + k
+			if !has {
+				if cn.required {
+					verr.add(kpath, "value is required")
+					continue
+				}
+				if cn.defaultValue != nil || cn.kind == KindNull || cn.kind == KindObject || cn.kind == KindArray {
+					out[k] = cloneDefault(cn)
+				}
+				continue
+			}
+			out[k] = validateNode(cn, v, kpath, verr)
+		}
+
+		if !n.open {
+			for k := range obj {
+				if _, ok := n.objChildren[k]; !ok {
+					verr.add(path+"."+k, "property is not allowed")
+				}
+			}
+		}
+
+		return out
+	default:
+		verr.add(path, "unknown schema kind")
+		return in
+	}
+}
+
+func cloneDefault(n *node) any {
+	switch n.kind {
+	case KindObject:
+		out := map[string]any{}
+		for k, cn := range n.objChildren {
+			if cn.required {
+				continue
+			}
+			if cn.defaultValue != nil || cn.kind == KindNull || cn.kind == KindObject || cn.kind == KindArray {
+				out[k] = cloneDefault(cn)
+			}
+		}
+		return out
+	case KindArray:
+		return []any{}
+	default:
+		return n.defaultValue
+	}
+}
+
+func isNumber(v any) bool {
+	switch v.(type) {
+	case int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64,
+		float32, float64:
+		return true
+	default:
+		return false
+	}
+}

--- a/test/compat.test.ts
+++ b/test/compat.test.ts
@@ -1,0 +1,132 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert'
+import fs from 'node:fs'
+import path from 'node:path'
+
+type Row = {
+  name: string
+  spec: any
+  input: any
+  output: any
+  error: string
+}
+
+const TSV_PATH = path.join(process.cwd(), 'test', 'compat.tsv')
+
+
+function parseValueCell(src: string): any {
+  const s = src.trim()
+
+  try {
+    return JSON.parse(s)
+  }
+  catch (_e) {
+    if (2 <= s.length) {
+      const q0 = s[0]
+      const q1 = s[s.length - 1]
+      if (("'" === q0 && "'" === q1) || ('"' === q0 && '"' === q1)) {
+        return s.slice(1, -1)
+      }
+    }
+
+    return s
+  }
+}
+
+function parseTSV(filePath: string): Row[] {
+  const src = fs.readFileSync(filePath, 'utf8').trim()
+  const lines = src.split(/\r?\n/)
+  const headers = lines[0].split('\t')
+
+  return lines.slice(1)
+    .filter(line => line.trim().length > 0)
+    .map(line => {
+      const cols = line.split('\t')
+      const row: any = {}
+      headers.forEach((h, i) => row[h] = cols[i] || '')
+
+      return {
+        name: row.name,
+        spec: parseValueCell(row.spec),
+        input: parseValueCell(row.input),
+        output: parseValueCell(row.output),
+        error: row.error,
+      }
+    })
+}
+
+function decodeSpec(v: any, Shape: any): any {
+  if (Array.isArray(v)) {
+    return v.map(x => decodeSpec(x, Shape))
+  }
+
+  if (null != v && 'object' === typeof v) {
+    const keys = Object.keys(v)
+
+    if (1 === keys.length && '$type' === keys[0]) {
+      const t = v.$type
+      const native: Record<string, any> = {
+        String,
+        Number,
+        Boolean,
+        Object,
+        Array,
+        Symbol,
+        Function,
+      }
+
+      return native[t] || Shape[t]
+    }
+
+    if (1 === keys.length && '$open' === keys[0]) {
+      return Shape.Open(decodeSpec(v.$open, Shape))
+    }
+
+    if (1 === keys.length && '$closed' === keys[0]) {
+      return Shape.Closed(decodeSpec(v.$closed, Shape))
+    }
+
+    if (1 === keys.length && '$required' === keys[0]) {
+      return Shape.Required(decodeSpec(v.$required, Shape))
+    }
+
+    if (1 === keys.length && '$optional' === keys[0]) {
+      return Shape.Optional(decodeSpec(v.$optional, Shape))
+    }
+
+    const out: Record<string, any> = {}
+    for (const k of keys) {
+      out[k] = decodeSpec(v[k], Shape)
+    }
+
+    return out
+  }
+
+  return v
+}
+
+
+describe('compat-tsv', () => {
+  let ShapeModule = require('../dist/shape')
+  if (ShapeModule.Shape) {
+    ShapeModule = ShapeModule.Shape
+  }
+
+  const Shape = ShapeModule
+
+  const rows = parseTSV(TSV_PATH)
+
+  for (const row of rows) {
+    test(row.name, () => {
+      const schema = Shape(decodeSpec(row.spec, Shape))
+
+      if (row.error) {
+        assert.throws(() => schema(structuredClone(row.input)), new RegExp(row.error, 'i'))
+        return
+      }
+
+      const out = schema(structuredClone(row.input))
+      assert.deepEqual(out, row.output)
+    })
+  }
+})

--- a/test/compat.tsv
+++ b/test/compat.tsv
@@ -1,0 +1,13 @@
+name	spec	input	output	error
+default-injection	{"port":8080,"host":"localhost"}	{"port":9090}	{"port":9090,"host":"localhost"}	
+required-token-missing	{"name":{"$type":"String"}}	{}	{}	required
+required-token-present	{"name":{"$type":"String"}}	{"name":"alice"}	{"name":"alice"}	
+closed-object-rejects-unknown	{"a":1}	{"a":2,"b":true}	{"a":2,"b":true}	not allowed
+open-object-allows-unknown	{"$open":{"a":1}}	{"a":2,"b":true}	{"a":2,"b":true}	
+array-child-number-valid	{"items":[{"$type":"Number"}]}	{"items":[1,2,3]}	{"items":[1,2,3]}	
+array-child-number-invalid	{"items":[{"$type":"Number"}]}	{"items":[1,"x",3]}	{"items":[1,"x",3]}	number
+nested-defaults	{"svc":{"port":8080,"host":"localhost"}}	{}	{"svc":{"port":8080,"host":"localhost"}}	
+literal-text-is-just-text	{"description":"64 characters, hexadecimal."}	{}	{"description":"64 characters, hexadecimal."}	
+single-quoted-scalar	'single quoted "text"'	"override"	"override"	
+double-quoted-scalar	"double quoted 'text'"	"override"	"override"	
+unquoted-scalar	unquoted text value	override raw	override raw	


### PR DESCRIPTION
### Motivation

- Provide an initial Go implementation of the `shape` schema-by-example validator mirroring key TypeScript semantics such as default injection, required markers, open/closed objects, and composer builders parity roadmap. 
- Expose a Go-friendly API that reproduces the TS constructor-vs-literal behavior via exported sentinel tokens (`String`, `Number`, `Boolean`, `Object`, `Array`).
- Outline a migration plan and directory layout to iteratively achieve parity and test compatibility with existing TS fixtures.

### Description

- Add a new `go` module with a `shape` package implementing a compiled `Schema` API via `Shape`, `MustShape`, and `Validate` in `schema.go` and module `go/go.mod` and docs in `go/README.md` and `go/PLAN.md`.
- Introduce sentinel type tokens and kinds in `tokens.go` (`TypeToken` and vars `String`, `Number`, `Boolean`, `Any`, `Object`, `Array`) to represent required type markers in schema-by-example maps.
- Implement schema normalization (`normalize.go`) and an internal `node` model (`node.go`) with wrappers for `Required`/`Optional`/`Open`/`Closed` semantics, and a validation engine (`validate.go`) that enforces types, injects defaults, recurses arrays/objects, and enforces open/closed object policies.
- Add validation error types and aggregation in `error.go`, plus unit tests in `shape_test.go` and a TSV-driven compatibility test harness in `compat_tsv_test.go` that decodes `test/compat.tsv` fixtures; also add a TypeScript test runner `test/compat.test.ts` and the TSV fixture `test/compat.tsv` for cross-language compatibility checks.

### Testing

- Ran `go test ./...` which executed the `shape` package unit tests including `shape_test.go` and the TSV compatibility reader test `compat_tsv_test.go`, and they passed.
- Added a Node/TS compatibility test harness in `test/compat.test.ts` and the fixture `test/compat.tsv` for future cross-language test runs, but the TS tests were not executed as part of the Go test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c40477c718832a90c739a1d6aa0bdb)